### PR TITLE
add port to start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Once you have a [Next app working locally](https://github.com/zeit/next.js#how-t
    ```json
    {
      "scripts": {
+       "start": "next start -p $PORT",
        "heroku-postbuild": "next build"
      }
    }


### PR DESCRIPTION
 `-p $PORT` is missing in next.js's production build guide, but seems to be necessary on heroku