### PR TITLE
Switch to Heroku Node.js auto-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,22 +23,24 @@ https://nextjs.herokuapp.com
 
 ## Production deployment
 
-Once you have a [Next app working locally](https://github.com/zeit/next.js#how-to-use), you may deploy it for public access.
+Once you have a [Next app working locally](https://nextjs.org/docs/#setup), you may deploy it for public access.
 
-1. Add the [`heroku-postbuild`](https://devcenter.heroku.com/articles/nodejs-support#heroku-specific-build-steps) hook to automatically build the Next app on each deployment:
+1. Revise the `npm start` script to set the [web listener `$PORT`](https://devcenter.heroku.com/articles/dynos#local-environment-variables):
 
    Merge this entry into **package.json**:
 
    ```json
    {
      "scripts": {
-       "start": "next start -p $PORT",
-       "heroku-postbuild": "next build"
+       "dev": "next",
+       "build": "next build",
+       "start": "next start -p $PORT"
      }
    }
    ```
 
-   🌈 *In February 2017, [Next was fixed](https://github.com/zeit/next.js/pull/1164), so the **[Heroku build adapter](https://github.com/mars/heroku-nextjs-build/blob/master/bin/heroku-nextjs-build) is no longer required**.*
+   ⭐️ *In March 2019, [Heroku began running `npm run build` automatically](https://devcenter.heroku.com/changelog-items/1573), so the old `heroku-postbuild` script entry is no longer required.*
+
 1. Ensure the app is a git repo, ignoring local-only directories:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start -p $PORT",
-    "heroku-postbuild": "npm run build"
+    "start": "next start -p $PORT"
   },
   "engines": {
     "node": "10"
@@ -27,8 +26,8 @@
   },
   "homepage": "https://github.com/mars/heroku-nextjs#readme",
   "dependencies": {
-    "next": "8.0.3",
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "next": "^8.0.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6"
   }
 }


### PR DESCRIPTION
Includes:

* use Node.js buildpack's [build process](https://devcenter.heroku.com/articles/nodejs-support#customizing-the-build-process) (switch from `heroku-postbuild` to `build`)
* revising & clarifying documentation 📚
* fixups to ensure current **react** & **react-dom** versions.