### PR TITLE
Always check $PORT first

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,22 +25,6 @@ https://nextjs.herokuapp.com
 
 Once you have a [Next app working locally](https://nextjs.org/docs/#setup), you may deploy it for public access.
 
-1. Revise the `npm start` script to set the [web listener `$PORT`](https://devcenter.heroku.com/articles/dynos#local-environment-variables):
-
-   Merge this entry into **package.json**:
-
-   ```json
-   {
-     "scripts": {
-       "dev": "next",
-       "build": "next build",
-       "start": "next start -p $PORT"
-     }
-   }
-   ```
-
-   ⭐️ *In March 2019, [Heroku began running `npm run build` automatically](https://devcenter.heroku.com/changelog-items/1573), so the old `heroku-postbuild` script entry is no longer required.*
-
 1. Ensure the app is a git repo, ignoring local-only directories:
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "description": "Deploy Next.js server-side React apps to Heroku",
   "scripts": {
-    "dev": "next",
+    "dev": "next -p ${PORT:-3000}",
     "build": "next build",
-    "start": "next start -p $PORT"
+    "start": "next start -p ${PORT:-3000}"
   },
   "engines": {
     "node": "10"


### PR DESCRIPTION
Update npm dev scripts to always use `-p PORT` for dev and production run scripts. Uses the `${PORT:-3000}` to fallback to using Next.js's standard 3000 port number when the environment variable is not defined.

Removed unnecessary step from the README.